### PR TITLE
Fix accent style

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import ReviewAndSubmit from "./ReviewAndSubmit.jsx";
 
 // Import logo from public folder
 import assuraLogo from "./assets/assura_logo.svg"; // (if you want to use the SVG in the future)
-import assuraLogoPng from "./assets/assura_logo.png"; // import the PNG
 
 // Navbar component
 function Navbar() {

--- a/src/DirectoriesAndAccess.jsx
+++ b/src/DirectoriesAndAccess.jsx
@@ -49,7 +49,6 @@ export default function DirectoriesAndAccess({ formData, handleChange }) {
               value={option}
               checked={Array.isArray(formData.fileAccess) && formData.fileAccess.includes(option)}
               onChange={handleFileAccessChange}
-              className="accent-[#9375B2]"
             />
             <span className="ml-2">{option}</span>
           </label>


### PR DESCRIPTION
## Summary
- remove redundant `accent-[#9375B2]` class from directories access checkbox
- clean up unused logo import in `App.jsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686662e7a280832f9346854a2ab04b34