### PR TITLE
Add logo shadow CSS utility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import ReviewAndSubmit from "./ReviewAndSubmit.jsx";
 
 // Import logo from public folder
 import assuraLogo from "./assets/assura_logo.svg"; // (if you want to use the SVG in the future)
-import assuraLogoPng from "./assets/assura_logo.png"; // import the PNG
 
 // Navbar component
 function Navbar() {
@@ -31,8 +30,7 @@ function SplashScreen() {
       <img
         src={assuraLogo}
         alt="Assura Logo"
-        className="w-64 max-w-xs animate-pulse transition-all duration-700"
-        style={{ filter: "drop-shadow(0 0 24px #1E3E89)" }}
+        className="w-64 max-w-xs animate-pulse transition-all duration-700 logo-shadow"
       />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,8 @@ input[type="checkbox"] {
 .react-datepicker * {
   font-family: 'Century Gothic', Arial, sans-serif !important;
 }
+
+/* Utility class for drop shadow on the splash screen logo */
+.logo-shadow {
+  filter: drop-shadow(0 0 24px #1E3E89);
+}


### PR DESCRIPTION
## Summary
- add `.logo-shadow` utility class to centralize splash screen styling
- use the new utility on the splash screen image and clean up unused asset import

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686662ec9e88832fa1bf44cbb1152be4